### PR TITLE
xss-lock.service: Use XDG_SESSION_ID and give hint about setting it.

### DIFF
--- a/doc/xss-lock.service
+++ b/doc/xss-lock.service
@@ -4,7 +4,10 @@ PartOf=graphical-session.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/xss-lock -l -s ${GRAPHICAL_SESSION_ID} -- i3lock
+# You must arrange to run `systemctl --user import-environment
+# XDG_SESSION_ID` in your X environment prior to launching the user
+# session, e.g. in your `.xsessionrc` or similar.
+ExecStart=/usr/bin/xss-lock -l -s ${XDG_SESSION_ID} -- i3lock
 
 [Install]
 WantedBy=graphical-session.target


### PR DESCRIPTION
I don't use this myself but this is based on discussion in https://bugs.debian.org/994762 and https://bugs.debian.org/1029513.

`$GRAPHICAL_SESSION_ID` doesn't appear to have ever been a thing.