### PR TITLE
Revert and reimplement the --ignore-xss switch while keeping logind IdleHint support

### DIFF
--- a/src/xss-lock.c
+++ b/src/xss-lock.c
@@ -65,7 +65,6 @@ static Child locker = {"locker", NULL, 0, FALSE, &notifier};
 static gboolean opt_quiet = FALSE;
 static gboolean opt_verbose = FALSE;
 static gboolean opt_ignore_sleep = FALSE;
-static gboolean opt_ignore_xss = FALSE;
 static gboolean opt_print_version = FALSE;
 static gchar *opt_session = NULL;
 
@@ -74,7 +73,6 @@ static GOptionEntry opt_entries[] = {
     {"notifier", 'n', G_OPTION_FLAG_FILENAME, G_OPTION_ARG_CALLBACK, parse_notifier_cmd, "Send notification using CMD", "CMD"},
     {"transfer-sleep-lock", 'l', 0, G_OPTION_ARG_NONE, &locker.transfer_sleep_lock_fd, "Pass sleep delay lock file descriptor to locker", NULL},
     {"ignore-sleep", 0, 0, G_OPTION_ARG_NONE, &opt_ignore_sleep, "Do not lock on suspend/hibernate", NULL},
-    {"ignore-xss", 0, 0, G_OPTION_ARG_NONE, &opt_ignore_xss, "Do not lock on X screen saver events", NULL},
     {"quiet", 'q', 0, G_OPTION_ARG_NONE, &opt_quiet, "Output only fatal errors", NULL},
     {"verbose", 'v', 0, G_OPTION_ARG_NONE, &opt_verbose, "Output more messages", NULL},
     {"version", 0, 0, G_OPTION_ARG_NONE, &opt_print_version, "Print version number and exit", NULL},
@@ -584,14 +582,12 @@ main(int argc, char *argv[])
     g_unix_signal_add(SIGHUP,  (GSourceFunc)exit_service, loop);
 
     default_screen = xcb_aux_get_screen(connection, default_screen_number);
-    if (!opt_ignore_xss) {
-        if (!register_screensaver(connection, default_screen, &atom, &error))
-            goto init_error;
-    }
+    if (!register_screensaver(connection, default_screen, &atom, &error))
+        goto init_error;
 
     g_main_loop_run(loop);
 
-    if (!opt_ignore_xss) unregister_screensaver(connection, default_screen, atom);
+    unregister_screensaver(connection, default_screen, atom);
     g_main_loop_unref(loop);
     if (sleep_lock_fd >= 0) close(sleep_lock_fd);
     if (logind_manager) g_object_unref(logind_manager);


### PR DESCRIPTION
Using --ignore-xss broke logind IdleHint support (was not set/unset any more).

This version allows to disable locker-starts on xss-events while still having
logind IdleHint managed and also allows notifier starts if such given.

Note about systemd logind:
logind expects graphical sessions to set IdleHint=yes on their own
(auto-detection only works for plain text sessions of Type=tty)
Machine won't be suspended by logind in spite of IdleAction was set
in logind.conf if one or more sessions stay on IdleHint=no.

edit/update: no need to disable notifier
2nd update: fix indentation and commit message