### PR TITLE
Bump minimum cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 project(xss-lock C)
 set(PROJECT_VERSION 0.3.0)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(xss-lock C)
 set(PROJECT_VERSION 0.3.0)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,7 @@ add_executable(xss-lock
     xss-lock.c
     xcb_utils.c
     xcb_utils.h
-    config.h
+    ${CMAKE_CURRENT_BINARY_DIR}/config.h
 )
 
 target_link_libraries(xss-lock ${GLIB2_LIBRARIES} ${XCB_LIBRARIES})


### PR DESCRIPTION
First to 3.5 and then to 3.10.

This was reported by the Debian cmake maintainer as http://bugs.debian.org/1113646.